### PR TITLE
Skipping twitter exceptions

### DIFF
--- a/like_and_share_twitter_bot/like_and_share_twitter_bot.py
+++ b/like_and_share_twitter_bot/like_and_share_twitter_bot.py
@@ -21,9 +21,17 @@ class LikeAndShareTwitterBot:
         with open('/tmp/liked_tweets', 'a') as myfile:
             myfile.write(selected.text)
         if random.randint(0,100) < config.GENERAL_CONFIG['chanceToFavorite']:
+          try:
             api.CreateFavorite(selected)
+          except twitter.error.TwitterError as e:
+            #Do nothing for now
+            pass
         if random.randint(0,100) < config.GENERAL_CONFIG['chanceToFollow']:
+          try:
             api.CreateFriendship(selected.user.id)
+          except twitter.error.TwitterError as e:
+            #Do nothing for now
+            pass
 
 if __name__ == '__main__':
     if random.randint(0,100) < config.GENERAL_CONFIG['chanceToAct']:


### PR DESCRIPTION
Fixes #1 by silently skipping Twitter errors when marking a tweet as favorite or following a user.